### PR TITLE
docs: update demo changes for collections file and note on exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ## Table of Contents
 
-
   - [INTRODUCTION](#introduction)
   - [Pre-requisites:](#pre-requisites)
   - [INSTALLATION STEPS](#installation-steps)
@@ -132,6 +131,8 @@ Any terminal: `./start.sh`
 
 Toggle any or no addons
 
+> NOTE: It is currently not possible to select `Authentication` and `Demo UI` at the same time.
+
 ![start-services-2](/images/full-stack-docker-tazama-start-bat-2.png)
 
 Apply configuration
@@ -172,15 +173,6 @@ curl localhost:5000
 
 ![execute-config](./images/full-stack-docker-tazama-curl.png)
 
-## 5. Configure Tazama
-
-Tazama is configured by loading the network map, rules and typology configurations required to evaluate a transaction via the ArangoDB API. The steps above have already loaded the default configuration into the database.
-
-For an optional step to load the Tazama configuration manually, follow the instructions in the [Appendix](#appendix)
-
-**Output:**
-
-![compose-rule-901](./images/full-stack-docker-tazama-compose-rule-901.png)
 
 ## TESTING THE END-TO-END DEPLOYMENT
 
@@ -202,7 +194,10 @@ We can run the following Postman test via Newman to see if our deployment was su
 newman run collection-file -e environment-file --timeout-request 10200 --delay-request 500
 ```
 
- - If the authentication option has not been selected, then the `collection-file` is the full path to the location on your local machine where the `postman\1.1. (NO-AUTH) Rule-901 End-to-End test - pain001-013 disabled.postman_collection.json` file is located. If authentication is deployed, use `postman\1.2. (AUTH) Rule-901 End-to-End test - pain001-013 disabled.postman_collection.json`.
+- Select one of the following `collection file` options:
+   - If the authentication option has not been selected, then the `collection-file` is the full path to the location on your local machine where the `postman\1.1. (NO-AUTH) Rule-901 End-to-End test - pain001-013 disabled.postman_collection.json` file is located. 
+   - If authentication is deployed, use `postman\1.2. (AUTH) Rule-901 End-to-End test - pain001-013 disabled.postman_collection.json`.
+   - If the demo UI is selected (which must be without Authentication) use `postman\1.3. (NO-AUTH-DEMO) Rule-901 End-to-End test - pain001-013 disabled.postman_collection.json` 
  - The `environment-file` is the full path to the location on your local machine where the `postman\environments\Tazama-Docker-Compose-LOCAL.postman_environment.json` file is located.
  - If the path contains spaces, wrap the string in double-quotes.
  - We add the `--delay-request` option to delay each individual test by 500 milliseconds to give them evaluation time to complete before we look for the result in the database.
@@ -220,7 +215,7 @@ The services are split up in multiple yamls,
 | docker-compose | tms, ed, tp, tadp, admin, ef |
 | docker-compose.override | rule-901, set up all services |
 | docker-compose.infrastructure | arango, nats, valkey |
-| docker-compose.dev.nats-utils | Nats-Utilities |
+| docker-compose.dev.nats-utils | nats-utilities |
 | docker-compose.dev.auth | keycloak, auth-service, tms changes |
 | docker-compose.dev.logs-base | event-sidecar, lumberjack, all service changes |
 | docker-compose.dev.logs-elastic | event-sidecar, lumberjack, elasticsearch, kibana |
@@ -262,7 +257,7 @@ List of \<services\>
 
 ## Appendix
 
-This appendix will show you how to optionally load the configuration and environment files in the Tazama full stack docker deployment.
+This appendix will show you how to manually load the configuration and environment files in the Tazama full stack docker deployment.
 
 In a Windows Command Prompt, navigate to the source code root folder. Then clone the following repository with the following command:
 ```


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

A third collection has been added for the newman test 1.3. NO-AUTH-DEMO
Added a note re: can't select demo and auth at the same time
Deleted a duplicated section

## Why are we doing this?

Changes required to documentation for demo deployment

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
