### PR TITLE
fix(efrup): suppress alerts off with relay

### DIFF
--- a/docker-compose.dev.relay.yaml
+++ b/docker-compose.dev.relay.yaml
@@ -1,4 +1,7 @@
 services:
+  ef:
+    environment:
+      SUPPRESS_ALERTS: false
   tp:
     environment:
       SUPPRESS_ALERTS: false


### PR DESCRIPTION
## What did we change?
`SUPPRESS_ALERTS=false` for EFRuP when relay is deployed

## Why are we doing this?
#91 

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
