### PR TITLE
fix: missing rule on windows script

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -68,7 +68,7 @@ if "%choice%"=="99" if "%natsutils%" == "[ ]" (set "natsutils=[X]") else (set "n
 goto :addons
 
 :apply
-set "cmd=docker compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.dev.db.yaml"
+set "cmd=docker compose -f docker-compose.yaml -f docker-compose.override.yaml -f docker-compose.dev.db.yaml -f docker-compose.dev.rule.yaml -f docker-compose.dev.yaml"
 if "%auth%" == "[X]" (
     if "%IS_GITHUB_DEPLOYMENT%" == "1" (
         set "cmd=%cmd% -f docker-compose.dev.auth.yaml -f docker-compose.auth.base.yaml"


### PR DESCRIPTION
## What did we change?
dev rule was missing in batch script

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
