### PR TITLE
fix: Updated rule-901 config to narrow bands

### DIFF
--- a/arango/migration/local/01-STANDARD.js
+++ b/arango/migration/local/01-STANDARD.js
@@ -24,13 +24,13 @@ const ruleConfigData = [
         {
           subRuleRef: ".02",
           lowerLimit: 2,
-          upperLimit: 4,
-          reason: "The debtor has performed two or three transactions to date",
+          upperLimit: 3,
+          reason: "The debtor has performed two transactions to date",
         },
         {
           subRuleRef: ".03",
-          lowerLimit: 4,
-          reason: "The debtor has performed 4 or more transactions to date",
+          lowerLimit: 3,
+          reason: "The debtor has performed three or more transactions to date",
         },
       ],
     },


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Narrowed the bands for rule-901 to 1, 2, and 3+ transactions instead of 1, 2-3 and 4+ transactions.

## Why are we doing this?

Make the testing easier.
Align the configs for the different setup options

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [X] Unit tests passing and Documentation done
