### PR TITLE
fix: The docker-compose.auth.yaml and docker-compose.infrastructure.yaml incorrect

### DIFF
--- a/docker-compose.auth.yaml
+++ b/docker-compose.auth.yaml
@@ -30,5 +30,4 @@ services:
       - 3020:3020
     restart: always
     depends_on:
-      - arango
       - keycloak

--- a/docker-compose.infrastructure.yaml
+++ b/docker-compose.infrastructure.yaml
@@ -20,6 +20,8 @@ services:
     command:
       - arangod
       - --server.endpoint=tcp://0.0.0.0:8529
+    ports:
+      - 18529:8529
     volumes:
       - ./arango/migration/base/00-CREATE.js:/docker-entrypoint-initdb.d/00-CREATE.js
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0
The docker-compose.auth.yaml  has a dependency on Arango (that is not part of the yaml)

The docker-compose.infrastructure.yaml does not expose Arango ports

## What did we change?
The docker-compose.auth.yaml  has a dependency on Arango (that is not part of the yaml) - removed

The docker-compose.infrastructure.yaml does not expose Arango ports - added ports

## Why are we doing this?
So the components deploy consistently

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
